### PR TITLE
Get working with 1.2 & exposed api.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
-FROM alpine
+FROM ubuntu
 MAINTAINER Roy Lines <https://roylines.co.uk>
 
-RUN apk add --update wget ca-certificates
-RUN rm -rf /var/cache/apk/*
-
+RUN apt-get install -y wget unzip
 RUN mkdir /etc/nomad.d
 RUN chmod a+w /etc/nomad.d
 
-RUN wget https://s3.amazonaws.com/hc-public/nomad/0.1.0dev/nomad_linux_amd64 -O /usr/bin/nomad --no-check-certificate
+RUN wget https://releases.hashicorp.com/nomad/0.1.2/nomad_0.1.2_linux_amd64.zip -O nomad.zip --no-check-certificate
+RUN unzip nomad.zip
+RUN mv nomad /usr/bin/nomad
 RUN chmod +x /usr/bin/nomad
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+
+# Expose HTTP API port
+EXPOSE 4646
+
+CMD ["/usr/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export IP=$(ip addr show eth0 | grep inet | grep global | awk '{ print $2 }' | awk -F / '{ print $1 }')
+echo "Binding to eth0: $IP"
+/usr/bin/nomad agent -dev -bind $IP


### PR DESCRIPTION
Hi Roy,

This exposes the nomad HTTP API so, whether it will actually run docker containers or not (for which we might want to look at the docker:dind image and the -privileged flag), it can be used for rudimentary API testing.

I had to move away from Alpine as busybox was claiming it couldn't find the nomad binary (despite being in /usr/bin), I suspect because of some binary format or dependency issue. 

Greg
